### PR TITLE
Dev/add cookie banner#250

### DIFF
--- a/app/assets/css/banner.css
+++ b/app/assets/css/banner.css
@@ -1,0 +1,3 @@
+.v-application--wrap{
+    min-height: 0vh;
+}

--- a/app/assets/css/globalstyles.scss
+++ b/app/assets/css/globalstyles.scss
@@ -240,3 +240,7 @@ span.moresign {
 .tag-block {
   @apply bg-white mr-2 mb-2 px-3 py-1 inline-block;
 }
+
+.v-application--wrap{
+  min-height: 0vh;
+}

--- a/app/assets/css/globalstyles.scss
+++ b/app/assets/css/globalstyles.scss
@@ -240,7 +240,3 @@ span.moresign {
 .tag-block {
   @apply bg-white mr-2 mb-2 px-3 py-1 inline-block;
 }
-
-.v-application--wrap{
-  min-height: 0vh;
-}

--- a/app/components/Banner.vue
+++ b/app/components/Banner.vue
@@ -28,7 +28,7 @@ export default {
     methods: {
         dismiss_remember: function (event) {
             // `this` inside methods points to the Vue instance
-            window.localStorage.lahma_cookie_info_banner_status = 'dismissed';
+            window.localStorage.lahma_cookie_info_banner_dismiss_date = new Date();
             this.isRemembered = true
         }
     },
@@ -36,11 +36,12 @@ export default {
         return {
             //Note: as window object is not available in early phases in the instance creation, we need to update the value when the component is mounted
             //Initial value can be assumed to be true so that nothing is displayed when rendering
-            isRemembered: true
+            isRemembered: false
         }
     },
     mounted () {            
-            this.isRemembered = window.localStorage.lahma_cookie_info_banner_status ? true : false
+            var dismissalAge = (new Date() - new Date(window.localStorage.lahma_cookie_info_banner_dismiss_date))/1000/60/60/24; //convert from ms to days
+            this.isRemembered = (dismissalAge < 30) ? true : false; //show banner again after 30 days of last dismissal
     },
     computed: {
         isNone () {

--- a/app/components/Banner.vue
+++ b/app/components/Banner.vue
@@ -1,6 +1,6 @@
 <template>
     <v-app>
-        <div v-bind:style="{ display: isRemembered }">
+        <div v-bind:style="{ display: isNone }">
         <v-banner
           single-line
           color="yellow"
@@ -28,18 +28,24 @@ export default {
     methods: {
         dismiss_remember: function (event) {
             // `this` inside methods points to the Vue instance
-            window.localStorage.lahma_cookie_info_banner_status = 'none';
-            this.isRemembered = 'none'
+            window.localStorage.lahma_cookie_info_banner_status = 'dismissed';
+            this.isRemembered = true
         }
     },
     data () {
         return {
             //Note: as window object is not available in early phases in the instance creation, we need to update the value when the component is mounted
-            isRemembered: 'none'
+            //Initial value can be assumed to be true so that nothing is displayed when rendering
+            isRemembered: true
         }
     },
     mounted () {            
-            this.isRemembered = window.localStorage.lahma_cookie_info_banner_status
+            this.isRemembered = window.localStorage.lahma_cookie_info_banner_status ? true : false
+    },
+    computed: {
+        isNone () {
+            return this.isRemembered ? 'none' : 'block'
+        }
     }
 };
 </script>

--- a/app/components/Banner.vue
+++ b/app/components/Banner.vue
@@ -1,5 +1,6 @@
 <template>
     <v-app>
+        <div v-bind:style="{ display: isRemembered }">
         <v-banner
           single-line
           color="yellow"
@@ -9,22 +10,37 @@
             color="black">
                 mdi-cookie
         </v-icon>
-        Használunk stüiket, részletek <NuxtLink to="/cookies/">itt</NuxtLink>. 
-        <template v-slot:actions="{ dismiss }">
+        Használunk sütiket, részletek <NuxtLink to="/cookies/">itt</NuxtLink>. 
             <v-btn
                 text
                 color="primary"
-                @click="dismiss">
+                @click="dismiss_remember">
                 Dismiss
             </v-btn>
-        </template>
-    </v-banner>
+        </v-banner>
+        </div>
   </v-app>
 </template>
   
 <script>
 export default {
-    name: 'Banner'
+    name: 'Banner',
+    methods: {
+        dismiss_remember: function (event) {
+            // `this` inside methods points to the Vue instance
+            window.localStorage.lahma_cookie_info_banner_status = 'none';
+            this.isRemembered = 'none'
+        }
+    },
+    data () {
+        return {
+            //Note: as window object is not available in early phases in the instance creation, we need to update the value when the component is mounted
+            isRemembered: 'none'
+        }
+    },
+    mounted () {            
+            this.isRemembered = window.localStorage.lahma_cookie_info_banner_status
+    }
 };
 </script>
 

--- a/app/components/Banner.vue
+++ b/app/components/Banner.vue
@@ -1,0 +1,38 @@
+<template>
+        <v-app>
+        <v-banner
+          color="white">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent cursus nec sem id malesuada.
+    Curabitur lacinia sem et turpis euismod, eget elementum ex pretium.
+    <template v-slot:actions>
+      <v-btn
+        text
+        color="primary"
+      >
+        Dismiss
+      </v-btn>
+      <v-btn
+        text
+        color="primary"
+      >
+        Retry
+      </v-btn>
+    </template>
+  </v-banner>
+  </v-app>
+</template>
+  
+<script>
+export default {
+    name: 'Banner'
+};
+</script>
+
+<style lang="scss" scoped>
+    @import '~vuetify/src/components/VStepper/_variables.scss';
+
+    .v-banner{
+        position:fixed;
+        bottom:50px;        
+    }
+</style>

--- a/app/components/Banner.vue
+++ b/app/components/Banner.vue
@@ -1,24 +1,24 @@
 <template>
-        <v-app>
+    <v-app>
         <v-banner
-          color="white">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent cursus nec sem id malesuada.
-    Curabitur lacinia sem et turpis euismod, eget elementum ex pretium.
-    <template v-slot:actions>
-      <v-btn
-        text
-        color="primary"
-      >
-        Dismiss
-      </v-btn>
-      <v-btn
-        text
-        color="primary"
-      >
-        Retry
-      </v-btn>
-    </template>
-  </v-banner>
+          single-line
+          color="yellow"
+          rounded>
+         <v-icon
+            icon="mdi-cookie"
+            color="black">
+                mdi-cookie
+        </v-icon>
+        Használunk stüiket, részletek <NuxtLink to="/cookies/">itt</NuxtLink>. 
+        <template v-slot:actions="{ dismiss }">
+            <v-btn
+                text
+                color="primary"
+                @click="dismiss">
+                Dismiss
+            </v-btn>
+        </template>
+    </v-banner>
   </v-app>
 </template>
   
@@ -34,5 +34,6 @@ export default {
     .v-banner{
         position:fixed;
         bottom:50px;        
-    }
+        opacity:0.9;
+    }    
 </style>

--- a/app/components/Banner.vue
+++ b/app/components/Banner.vue
@@ -29,7 +29,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    @import '~vuetify/src/components/VStepper/_variables.scss';
+    @import '@/assets/css/banner.css'; //for Vuetify style overrides; probably not needed here, but it's a good placeholder too see where overrides styles can be defined
 
     .v-banner{
         position:fixed;

--- a/app/constants/index.js
+++ b/app/constants/index.js
@@ -30,6 +30,7 @@ export const labsSectionURL = contentApiURL + '/pages/3091'
 export const recipeSectionURL = contentApiURL + '/pages/3093'
 export const rareShowsURL = contentApiURL + '/pages/3721'
 export const bannerTextURL = contentApiURL + '/pages/3932'
+export const cookiesPageURL = contentApiURL + '/pages/3923'
 
 export const lahmaGaleriesURL = contentApiURL + '/lahma_gallery'
 export const mediaURL = contentApiURL + '/media'

--- a/app/constants/index.js
+++ b/app/constants/index.js
@@ -29,6 +29,7 @@ export const pressSectionURL = contentApiURL + '/pages/3087'
 export const labsSectionURL = contentApiURL + '/pages/3091'
 export const recipeSectionURL = contentApiURL + '/pages/3093'
 export const rareShowsURL = contentApiURL + '/pages/3721'
+export const bannerTextURL = contentApiURL + '/pages/3932'
 
 export const lahmaGaleriesURL = contentApiURL + '/lahma_gallery'
 export const mediaURL = contentApiURL + '/media'

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -5,6 +5,7 @@
     <FooterHome v-if="$route.name === 'index'" />
     <FooterBottom v-else />
     <BottomArcsiPlayer />
+    <Banner />
   </div>
 </template>
 

--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -64,7 +64,8 @@ export default {
   modules: [
     '@nuxtjs/axios',
     '@nuxtjs/sentry',
-    'v-sanitize/nuxt'
+    'v-sanitize/nuxt',
+    'nuxt-cookie-control'
   ],
   axios: {
     // proxyHeaders: false

--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -56,7 +56,8 @@ export default {
     // Doc: https://github.com/nuxt-community/nuxt-tailwindcss
     '@nuxtjs/tailwindcss',
     '@nuxtjs/style-resources',
-    '@nuxtjs/moment'
+    '@nuxtjs/moment',
+    '@nuxtjs/vuetify'
   ],
   /*
   ** Nuxt.js modules
@@ -106,5 +107,9 @@ export default {
     nuxtjs: 'What happened? 🙀🐁',
     back_to_home: '🗣 Back home! 🎅🧨👉',
     server_error_details: 'Server errorrrrr or unreachable 🤯'
-  }
+  },
+    vuetify: {
+      customVariables: ['@/assets/css/globalstyles'],
+      treeShake: true
+    }
 }

--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -64,8 +64,7 @@ export default {
   modules: [
     '@nuxtjs/axios',
     '@nuxtjs/sentry',
-    'v-sanitize/nuxt',
-    'nuxt-cookie-control'
+    'v-sanitize/nuxt'
   ],
   axios: {
     // proxyHeaders: false

--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -109,7 +109,7 @@ export default {
     server_error_details: 'Server errorrrrr or unreachable 🤯'
   },
     vuetify: {
-      customVariables: ['@/assets/css/globalstyles'],
+      customVariables: ['@/assets/css/globalstyles', '@/assets/css/banner'],
       treeShake: true
     }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -37,6 +37,7 @@
     "@tailwindcss/postcss7-compat": "npm:@tailwindcss/postcss7-compat",
     "autoprefixer": "^9.8.8",
     "postcss": "^7.0.39",
-    "tailwindcss": "npm:@tailwindcss/postcss7-compat"
+    "tailwindcss": "npm:@tailwindcss/postcss7-compat",
+    "@nuxtjs/vuetify":"1.12.3"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,8 @@
     "vue-sanitize-directive": "^0.1.0",
     "vue-slider-component": "^3.2.15",
     "vuex-persist": "^3.1.3",
-    "webpack": "^4.46.0"
+    "webpack": "^4.46.0",
+    "nuxt-cookie-control": "^1.9.91"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config": "^6.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -27,8 +27,7 @@
     "vue-sanitize-directive": "^0.1.0",
     "vue-slider-component": "^3.2.15",
     "vuex-persist": "^3.1.3",
-    "webpack": "^4.46.0",
-    "nuxt-cookie-control": "^1.9.91"
+    "webpack": "^4.46.0"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config": "^6.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,6 @@
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/sentry": "^5.1.5",
     "eslint": "^7.32.0",
-    "fibers": "^5.0.0",
     "html-entities": "^2.3.2",
     "nuxt": "^2.15.8",
     "sass": "^1.43.3",

--- a/app/pages/cookies.vue
+++ b/app/pages/cookies.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <SubTitle title="Lahmacun radio - Cookies" :maintitle="true" />
+    <SubTitle title="Website cookies" :maintitle="true" />
     <div class="container my-8">
       <div v-if="$fetchState.pending" class="center">
         Loading...

--- a/app/pages/cookies.vue
+++ b/app/pages/cookies.vue
@@ -1,0 +1,87 @@
+<template>
+  <div>
+    <SubTitle title="Lahmacun radio - Cookies" :maintitle="true" />
+    <div class="container my-8">
+      <div v-if="$fetchState.pending" class="center">
+        Loading...
+      </div>
+      <article id="cookies-page" ref="cookies">
+        <div v-if="cookiesContent">
+          <h2>{{ cookiesContent.title.rendered }}</h2>
+          <span v-sanitize.nothing="cookiesContentResults" />
+        </div>
+      </article>
+    </div>
+  </div>
+</template>
+
+<script>
+import { cookiesPageURL } from '~/constants'
+
+export default {
+  data () {
+    return {
+      cookiesContent: null,
+    }
+  },
+  async fetch () {
+    this.cookiesContent = await this.$axios.get(`${cookiesPageURL}`)
+      .then((res) => {
+        if (res) {
+          return res.data
+        }
+      })
+      .catch((error) => {
+        this.$sentry.captureException(new Error('Cookies page info not available ', error))
+        this.$nuxt.error({ statusCode: 404, message: 'Cookies page info not available' })
+      })
+  },
+  head () {
+    return {
+      title: 'Lahmacun radio - Cookies',
+      meta: [
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Lahmacun radio - Cookie policy'
+        },
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: 'Lahmacun radio - Cookies'
+        },
+        {
+          hid: 'og:description',
+          name: 'og:description',
+          content: 'Lahmacun radio - Cookie policy'
+        }
+      ]
+    }
+  },
+  computed: {
+    cookiesContentResults () {
+      if (!this.cookiesContent?.content?.rendered) {
+        return 'No content'
+      }
+      return this.cookiesContent?.content?.rendered.replace(/target="_top"/g, 'target="_blank"')
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+p, div.CookieDeclarationType {
+    margin-bottom: 30px;
+}
+thead th {
+    background-color: rgba(88, 88, 88, 0.2);
+    text-transform: uppercase;
+}
+th {
+    text-align: left;
+}
+td {
+    border-bottom: 1px solid black;
+    width: auto;
+}
+</style>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1732,6 +1732,17 @@
     tailwindcss "^2.2.2"
     ufo "^0.7.5"
 
+"@nuxtjs/vuetify@1.12.3":
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/vuetify/-/vuetify-1.12.3.tgz#d4adf84e18fd474044bf971e7cc978e25eb16ba1"
+  integrity sha512-6uVL3cfESMB00eVjJTNkyU4jvuPTGPn1yteo7lQTH6v+fxHcPaOgvzVYHIKSHIz1DecuOiB5c9b+YjsRP5+C8A==
+  dependencies:
+    deepmerge "^4.2.2"
+    sass "~1.32.13"
+    sass-loader "^10.2.0"
+    vuetify "^2.6"
+    vuetify-loader "^1.7.3"
+
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
   resolved "https://registry.npmjs.org/@nuxtjs/youch/-/youch-4.2.3.tgz"
@@ -3037,6 +3048,11 @@ caller-path@^2.0.0:
   dependencies:
     caller-callsite "^2.0.0"
 
+callsite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+  integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
+
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz"
@@ -3916,6 +3932,13 @@ debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
+decache@^4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/decache/-/decache-4.6.1.tgz#5928bfab97a6fcf22a65047a3d07999af36efaf0"
+  integrity sha512-ohApBM8u9ygepJCjgBrEZSSxPjc0T/PJkD+uNyxXPkqudyUpdXpwJYp0VISm2WrPVzASU6DZyIi6BWdyw7uJ2Q==
+  dependencies:
+    callsite "^1.0.0"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
@@ -4037,11 +4060,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detective@^5.2.0:
   version "5.2.0"
@@ -4797,13 +4815,6 @@ fastq@^1.6.0:
   integrity sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
   dependencies:
     reusify "^1.0.4"
-
-fibers@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz"
-  integrity sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==
-  dependencies:
-    detect-libc "^1.0.3"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -9057,6 +9068,13 @@ sass@^1.43.3:
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 
+sass@~1.32.13:
+  version "1.32.13"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.13.tgz#8d29c849e625a415bce71609c7cf95e15f74ed00"
+  integrity sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+
 sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
@@ -10380,6 +10398,20 @@ vue@^2.6.12, vue@^2.x:
   version "2.6.12"
   resolved "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz"
   integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+
+vuetify-loader@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/vuetify-loader/-/vuetify-loader-1.7.3.tgz#404657f4925c828f400fe3269003421d586835c6"
+  integrity sha512-1Kt6Rfvuw3i9BBlxC9WTMnU3WEU7IBWQmDX+fYGAVGpzWCX7oHythUIwPCZGShHSYcPMKSDbXTPP8UvT5RNw8Q==
+  dependencies:
+    decache "^4.6.0"
+    file-loader "^6.2.0"
+    loader-utils "^2.0.0"
+
+vuetify@^2.6:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.6.4.tgz#18052f77492d32856fea35c910755075ff32acc9"
+  integrity sha512-2wEzU/Gz39gQCxK93xoiWPKCHQUnyUKWd81wB7Q7hfYJWu5QOWQXYlF0X/BgUZzf8IOyHWKiSNEAfEe9OE3b4w==
 
 vuex-persist@^3.1.3:
   version "3.1.3"

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        proxy_pass http://app:3333;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}


### PR DESCRIPTION
The banner code and the CMS content are ready to review. 

Highlights: 

- The banner is using the **Vuetify** framework (an UI extension for Vue apps), which is new in our code base. 
- The banner status is stored in the browser's **local storage** (to remember the decision - cookie-like behaivor).
- The banner **text is configurable in our CMS** -> the content is fetched via Wordpress API. 
- The cookie policy page has been created in our CMS too based on a paid Cookiebot service -> again, the content is fetched via Wordpress API. 
 
As a result, wrong wording etc. from the CMS should not block the PR. 

The code has been validated as yarn dev application and it has also been built and validated locally and on dev, so that a review may not need to run the code. Attached is a screenshot how it looks like. 

The PR is structured through commits and commit messages. 

Please review. 

![image](https://user-images.githubusercontent.com/28865986/162433195-276cff64-957f-46ae-b963-54d2b8f56b30.png)
