### PR TITLE
Add reload script to nginx container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ./nginx:/etc/nginx/conf.d
     depends_on:
       - app
+    entrypoint: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
 
   certbot:
     depends_on:


### PR DESCRIPTION
Through a Let's Encrypt notification email I realised that the reload script in the nginx container was missing. I added it now to the the docker compose file. Please review. 