### PR TITLE
Quick solution for bringing back stream image in radio player

### DIFF
--- a/app/assets/css/_variables.scss
+++ b/app/assets/css/_variables.scss
@@ -12,3 +12,4 @@ $notebook-width: 1024px;
 $tablet-width: 768px;
 $mobile-width: 576px;
 $small-width: 380px;
+$extra-small-width: 330px;

--- a/app/components/HeaderBlock.vue
+++ b/app/components/HeaderBlock.vue
@@ -1,13 +1,13 @@
 <template>
   <header class="flex-row-reverse items-center justify-between px-4 py-2 bg-white md:flex md:flex-row">
-    <div class="flex items-center mb-4 xsm:mb-0 xsm:overflow-hidden">
+    <div class="flex items-start mb-4 xxsm:items-center xsm:mb-0 xsm:overflow-hidden">
       <div class="block mr-4 cursor-pointer" @click="$router.push('/')">
         <div class="main-title">
           Lahmacun Radio
         </div>
         <img src="@/assets/img/lahma_logo_1.svg" alt="Lahmacun Radio" class="w-24 logo">
       </div>
-      <div class="mt-2 xsm:my-4 md:mr-8">
+      <div class="xxsm:mt-2 xsm:my-4 md:mr-8">
         <client-only>
           <RadioPlayer :show-album-art="true" :now-playing-uri="streamServer" />
         </client-only>

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -498,12 +498,20 @@ export default {
         align-items: center;
         .now-playing-art {
           margin-right: 0.7rem;
+          @media (max-width: $extra-small-width) {
+            display: none;
+          }
         }
         .now-playing-main {
             flex: 1;
             min-width: 0;
             position: relative;
             height: 70px;
+            @media (max-width: $extra-small-width) {
+              height: auto;
+              margin-top: 0.25rem;
+              padding-right: 0.5rem;
+            }
             .media-body {
               overflow: auto;
             }
@@ -681,7 +689,7 @@ a.programimage {
 }
 #radio-player-controls.radio-controls-standalone {
     position: absolute;
-    background: white;
+    background: transparent;
     bottom: 3px;
     padding-left: 3px;
     line-height: 1;

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -11,15 +11,13 @@
             <img v-if="is_playing" src="@/assets/img/pause-gomb.svg" alt="Pause Lahmacun radio" class="pause-button">
             <img v-else src="@/assets/img/play_gomb.svg" alt="Play Lahmacun radio" class="play-button">
           </a>
-          <div v-if="false">
-            <!-- old show image -->
-            <div v-if="showAlbumArt && np.now_playing.song.art" class="now-playing-art">
-              <a class="cursor-pointer programimage" rel="playerimg" @click.stop="streamModal = !streamModal">
-                <div v-if="show_check === true" class="onair">On air</div>
-                <img class="progimg" :src="show_art_url" :alt="'album_art_alt'">
-              </a>
-              <Modal :media="show_art_url" :title="show_title" :description="show_subtitle" :visibility="streamModal" @close="closeModal" />
-            </div>
+          <!-- old show image -->
+          <div v-if="showAlbumArt && np.now_playing.song.art" class="now-playing-art">
+            <a class="cursor-pointer programimage" rel="playerimg" @click.stop="streamModal = !streamModal">
+              <div v-if="show_check === true" class="onair">On air</div>
+              <img class="progimg" :src="show_art_url" :alt="'album_art_alt'">
+            </a>
+            <Modal :media="show_art_url" :title="show_title" :description="show_subtitle" :visibility="streamModal" @close="closeModal" />
           </div>
 
           <div class="play-volume-controls">
@@ -116,7 +114,7 @@
             </div>
           </div>
         </div>
-        <div class="hidden sand-clock sm:block">
+        <div v-if="false" class="hidden sand-clock sm:block">
           <IconSandclock :progress="time_percent" :live="!!np.live.is_live.length" />
         </div>
       </div>
@@ -533,10 +531,8 @@ export default {
             text-overflow: ellipsis;
             overflow: hidden;
             white-space: nowrap;
-            &:hover {
-                /* text-overflow: clip;
-                white-space: normal;
-                word-break: break-all; */
+            @media (max-width: $small-width) {
+              white-space: normal;
             }
             a {
               display: block;
@@ -625,6 +621,10 @@ export default {
 a.programimage {
     width: 70px;
     height: 70px;
+    @media (max-width: $small-width) {
+      width: 60px;
+      height: 60px;
+    }
     display: block;
     overflow: hidden;
     position: relative;
@@ -732,7 +732,6 @@ a.programimage {
     }
   @media (max-width: $small-width) {
     min-width: auto;
-    width: 4.5rem;
   }
   img {
     padding: 0 0.75rem;

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -14,6 +14,7 @@ module.exports = {
   ],
   theme: {
     screens: {
+      xxsm: '330px',
       xsm: '380px',
       sm: '576px',
       md: '768px',


### PR DESCRIPTION
Quick fix for bringing back stream image. Cherry picked of commits of @baxgas (see commit refs in the commit message). We agreed on a 2-step solution by first bringing back the image in exchange for the sand watch, then working out a more sensitive solution as needed. In this commit we have logo-play/pause-image-title (from left to right) instead of logo-play/pause-title-image (as we agreed) but I think it's good enough for the 1st step (we got this solution "for free" through old commits and I wouldn't want to tweak around it for a temporary solution). Tested locally and on dev (active there, check it out, here's a screenshot of it), please review. 

![image](https://user-images.githubusercontent.com/28865986/167647914-47389c86-6e5b-498e-82c6-7017b13e5f56.png)

#225