### PR TITLE
Dev/show page metadata formatting update

### DIFF
--- a/app/pages/shows/_slug/index.vue
+++ b/app/pages/shows/_slug/index.vue
@@ -29,11 +29,13 @@
             <p>
               Airing time: {{ dayNames[showObject.day - 1] }} {{
                 removeSeconds(showObject.start)
-              }}–{{ removeSeconds(showObject.end) }},
-              {{ showFrequency(showObject.frequency, showObject.week) }}, Language: <span
-                v-sanitize.nothing="getLanguageGraph(showObject.language)"
-                class="language"
-              />
+              }}–{{ removeSeconds(showObject.end) }}
+            </p>
+            <p>
+              {{ showFrequency(showObject.frequency, showObject.week) }}
+            </p>
+            <p>
+              Language: <span v-sanitize.nothing="getLanguageGraph(showObject.language)" class="language"/>
             </p>
             <p v-if="showObject && getLatestEpisode">
               {{ showObject.active ? 'Show is active.' : 'Show is not active.' }}

--- a/app/pages/shows/_slug/index.vue
+++ b/app/pages/shows/_slug/index.vue
@@ -226,6 +226,7 @@ export default {
 }
 .show-infos {
   margin-bottom: 1rem;
+  font-style: italic;
 }
 .language {
   display: inline-block;

--- a/app/pages/shows/_slug/index.vue
+++ b/app/pages/shows/_slug/index.vue
@@ -37,16 +37,30 @@
             <p>
               Language: <span v-sanitize.nothing="getLanguageGraph(showObject.language)" class="language"/>
             </p>
-            <p>
+            <p v-if="showObject.archive_mixcloud_base_url">
               Elsewhere on web:
+              <!-- Quick fix: we (mis)use Mixcloud links (originally meant for another upload platform) as arbitrary external link. -->
+              <!-- Note: link needs to be full path and it will be displayed! -->
               <a class="show-external-link" :href="showObject.archive_mixcloud_base_url" target="_blank">
                 {{ showObject.archive_mixcloud_base_url }}
               </a>
             </p>
           </div>
+          <!-- Inactive shows: currently hard-coded for more flexibility and readability -->
           <div v-else class="show-infos">
             <p>
-              Bla
+              <strong>Show is not active.</strong>
+            </p>
+            <p>
+              Language: <span v-sanitize.nothing="getLanguageGraph(showObject.language)" class="language"/>
+            </p>
+            <p v-if="showObject.archive_mixcloud_base_url">
+              Elsewhere on web:
+              <!-- Quick fix: we (mis)use Mixcloud links (originally meant for another upload platform) as arbitrary external link. -->
+              <!-- Note: link needs to be full path and it will be displayed! -->
+              <a class="show-external-link" :href="showObject.archive_mixcloud_base_url" target="_blank">
+                {{ showObject.archive_mixcloud_base_url }}
+              </a>
             </p>
           </div>
           <div v-sanitize="[ sanitizeOptions, showObject.description ]" class="description-text" />

--- a/app/pages/shows/_slug/index.vue
+++ b/app/pages/shows/_slug/index.vue
@@ -27,12 +27,12 @@
           </h1>
           <div v-if="showObject.active" class="show-infos">
             <p>
-              Airing time: {{ dayNames[showObject.day - 1] }} {{
+              {{ dayNames[showObject.day - 1] }} {{
                 removeSeconds(showObject.start)
               }}–{{ removeSeconds(showObject.end) }}
             </p>
             <p>
-              {{ showFrequency(showObject.frequency, showObject.week) }}
+              {{ showFrequency(showObject.frequency, showObject.week, showObject.playlist_name) }}
             </p>
             <p>
               Language: <span v-sanitize.nothing="getLanguageGraph(showObject.language)" class="language"/>

--- a/app/pages/shows/_slug/index.vue
+++ b/app/pages/shows/_slug/index.vue
@@ -25,7 +25,7 @@
           <h1 class="mt-0 font-bold h2">
             {{ showObject.name }}
           </h1>
-          <div class="show-infos">
+          <div v-if="showObject.active" class="show-infos">
             <p>
               Airing time: {{ dayNames[showObject.day - 1] }} {{
                 removeSeconds(showObject.start)
@@ -37,12 +37,16 @@
             <p>
               Language: <span v-sanitize.nothing="getLanguageGraph(showObject.language)" class="language"/>
             </p>
-            <p v-if="showObject && getLatestEpisode">
-              {{ showObject.active ? 'Show is active.' : 'Show is not active.' }}
+            <p>
               Elsewhere on web:
               <a class="show-external-link" :href="showObject.archive_mixcloud_base_url" target="_blank">
                 {{ showObject.archive_mixcloud_base_url }}
               </a>
+            </p>
+          </div>
+          <div v-else class="show-infos">
+            <p>
+              Bla
             </p>
           </div>
           <div v-sanitize="[ sanitizeOptions, showObject.description ]" class="description-text" />
@@ -154,17 +158,7 @@ export default {
       const day = d.getDate().toLocaleString('en-US', { minimumIntegerDigits: 2 })
       return `${year}-${month}-${day}`
     },
-    getLatestEpisode () {
-      if (this.showObject?.items) {
-        const itemsSorted = this.showObject.items
-          .filter(show => show.play_date < this.getToday)
-          .filter(show => show.archived === true)
-          .sort((a, b) => b.number - a.number)
-          .sort((a, b) => new Date(b.play_date) - new Date(a.play_date))
-        return itemsSorted[0]
-      }
-      return null
-    },
+
     arcsiEpisodesList () {
       if (this.showObject?.items) {
         const itemsSorted = this.showObject.items

--- a/app/pages/shows/_slug/index.vue
+++ b/app/pages/shows/_slug/index.vue
@@ -37,11 +37,10 @@
             </p>
             <p v-if="showObject && getLatestEpisode">
               {{ showObject.active ? 'Show is active.' : 'Show is not active.' }}
-              Last episode:
-              <NuxtLink :to="{ path: `/shows/${slug}/${getLatestEpisode.name_slug}` }">
-                <strong>{{ getLatestEpisode.name }}</strong>
-              </NuxtLink>,
-              {{ $moment(getLatestEpisode.play_date).fromNow() }}.
+              Elsewhere on web:
+              <a class="show-external-link" :href="showObject.archive_mixcloud_base_url" target="_blank">
+                {{ showObject.archive_mixcloud_base_url }}
+              </a>
             </p>
           </div>
           <div v-sanitize="[ sanitizeOptions, showObject.description ]" class="description-text" />
@@ -220,6 +219,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
+.show-external-link {
+  text-decoration: underline;
+}
+
 .show-image {
     min-width: 300px;
     max-width: 360px;

--- a/app/pages/shows/_slug/index.vue
+++ b/app/pages/shows/_slug/index.vue
@@ -49,7 +49,7 @@
           <!-- Inactive shows: currently hard-coded for more flexibility and readability -->
           <div v-else class="show-infos">
             <p>
-              <strong>Show is not active.</strong>
+              <strong>Show is not active</strong>
             </p>
             <p>
               Language: <span v-sanitize.nothing="getLanguageGraph(showObject.language)" class="language"/>

--- a/app/plugins/mixinCommonMethods.js
+++ b/app/plugins/mixinCommonMethods.js
@@ -104,16 +104,20 @@ export function getLanguageGraph (type) {
   }
 }
 
-export function showFrequency (frequency) {
+export function showFrequency (frequency, week, playlist) {
   let showText = 'Not defined'
+  if (playlist === "Ritka csut" || playlist === "Ritka pentek"){
+    showText = 'New episode occasionally'
+    return showText
+  }
   if (frequency === 1) {
-    showText = 'New Episode: Monthly'
+    showText = 'New episode monthly'
   }
   if (frequency === 2) {
-    showText = 'New Episode: Every Second Week'
+    showText = 'New episode every second week'
   }
   if (frequency >= 3) {
-    showText = 'New Episode: Weekly'
+    showText = 'New episode weekly'
   }
   return showText
 }


### PR DESCRIPTION
Done with the changes based on spec. Special cases: 1) mixcloud (placeholder) link is empty, 2) is not empty, 3) show is inactive. The branch is live on dev, special cases are demonstrated via MMN, Torso, Konkrét report. Please review. 

Related PR: https://github.com/lahmacunradio/arcsi/pull/152