### PR TITLE
Dev/#278 display external stream info

### DIFF
--- a/app/components/HeaderBlock.vue
+++ b/app/components/HeaderBlock.vue
@@ -49,7 +49,7 @@ export default {
   methods: {
     getNow () {
       const today = new Date()
-      this.timestamp = today.getHours().toString().padStart(2, '0') + ':' + today.getMinutes().toString().padStart(2, '0')
+      this.timestamp = today.toLocaleString("en-EN", {timeZone: "Europe/Budapest", hour:"numeric", minute:"numeric", hour12: false})
 
       const minutes = today.getMinutes()
 

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -127,6 +127,7 @@ import VueSlider from 'vue-slider-component/dist-css/vue-slider-component.umd.mi
 import 'vue-slider-component/dist-css/vue-slider-component.css'
 // import theme
 import 'vue-slider-component/theme/default.css'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -190,6 +191,9 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({
+      todayShows: 'returnTodayShows'
+    }),
     streams () {
       const allStreams = []
       this.np.station.mounts.forEach(function (mount) {
@@ -243,7 +247,20 @@ export default {
       return (timeTotal) ? this.formatTime(timeTotal) : null
     },
     show_title () {
-      if (this.np.live.is_live) { return this.np.live.streamer_name } else { return this.np.now_playing.song.artist }
+      const title = ''
+      if (this.np.playlist !== '') // Show metadata can be served from Azuracast nowplaing API response
+        {
+          if (this.np.live.is_live) 
+            {title = this.np.live.streamer_name} else 
+            {title = this.np.now_playing.song.artist}
+        } else
+        {                         // Fallback: show metadata needs to be served from arcsi
+          title=''
+        } 
+        // Update show name in stream in store for other components
+        this.$store.commit('player/setStreamShowTitle', title)
+        return title
+
     },
     show_subtitle () {
       if (this.np.live.is_live) { return this.np.now_playing.song.title } else { return this.np.now_playing.song.title }

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -214,11 +214,7 @@ export default {
       return [...this.$store.getters.returnArcsiShows]
     },
     currentShowArcsi () {
-      if (this.np.live.is_live) { // live show
-        return this.arcsiList.find(show => this.slugify(show.name) === this.slugify(this.np.live.streamer_name))
-      } else { // pre-recorded show
-        return this.arcsiList.find(show => this.slugify(show.name) === this.slugify(this.np.now_playing.song.artist))
-      }
+      return this.arcsiList.find(show => this.slugify(show.name) === this.show_title)
     },
     time_percent () {
       const timePlayed = this.np.now_playing.elapsed
@@ -459,8 +455,6 @@ export default {
       this.$axios.get(this.nowPlayingUri).then((response) => {
         const npNew = response.data
         this.np = npNew
-        // Update show name in stream in store for other components
-        this.$store.commit('player/setStreamShowTitle', this.show_title())
         // Set a "default" current stream if none exists.
         if (this.current_stream.url === '' && npNew.station.listen_url !== '' && this.streams.length > 0) {
           let currentStream = null

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -255,7 +255,13 @@ export default {
             {title = this.np.now_playing.song.artist}
         } else
         {                         // Fallback: show metadata needs to be served from arcsi
-          title=''
+          for (let i = 0; i < this.todayShows.length; i++) {
+              let show = this.todayShows[i];
+              if (removeMinutesAndSeconds(show.start)<=getCurrentTimeHourCET()) { //as shows are timely ordered in input array, the first hit will be the currently running show
+                title=show.name;
+                break
+            }
+          }          
         } 
         // Update show name in stream in store for other components
         this.$store.commit('player/setStreamShowTitle', title)

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -247,7 +247,7 @@ export default {
       return (timeTotal) ? this.formatTime(timeTotal) : null
     },
     show_title () {
-      const title = ''
+      let title = ''
       if (this.np.playlist !== '') // Show metadata can be served from Azuracast nowplaing API response
         {
           if (this.np.live.is_live) 

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -274,12 +274,11 @@ export default {
     },
     show_check () {
       return !!(
-        this.np.live.is_live || 
-        (this.np.now_playing.playlist !== 'OFF AIR' && 
+        this.np.now_playing.playlist !== 'OFF AIR' && 
         this.np.now_playing.playlist !== 'Off Air Ambient' && 
         this.np.now_playing.playlist !== 'Jingle' && 
-        this.np.now_playing.playlist !== 'Jingle AFTER SHOW' && 
-        this.np.now_playing.playlist !== ''))
+        this.np.now_playing.playlist !== 'Jingle AFTER SHOW'
+      )
     },
     check_offairlink () {
       return this.np.now_playing.song.custom_fields.offairlink !== null && this.np.now_playing.song.custom_fields.offairlink.length > 3

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -273,7 +273,13 @@ export default {
       }
     },
     show_check () {
-      return !!(this.np.live.is_live || (this.np.now_playing.playlist !== 'OFF AIR' && this.np.now_playing.playlist !== 'Off Air Ambient' && this.np.now_playing.playlist !== 'Jingle' && this.np.now_playing.playlist !== 'Jingle AFTER SHOW' && this.np.now_playing.playlist !== ''))
+      return !!(
+        this.np.live.is_live || 
+        (this.np.now_playing.playlist !== 'OFF AIR' && 
+        this.np.now_playing.playlist !== 'Off Air Ambient' && 
+        this.np.now_playing.playlist !== 'Jingle' && 
+        this.np.now_playing.playlist !== 'Jingle AFTER SHOW' && 
+        this.np.now_playing.playlist !== ''))
     },
     check_offairlink () {
       return this.np.now_playing.song.custom_fields.offairlink !== null && this.np.now_playing.song.custom_fields.offairlink.length > 3
@@ -477,11 +483,11 @@ export default {
           })
           this.current_stream = currentStream
         }
-        // Optimisation: it should execute only once upon the first call and only if it's a scheduled show going on
-        if (this.show == null && this.show_check) { // Note: 'this.show == null' is also true if 'undefined'
+        // Optimisation: only call when it's a scheduled show going on
+        if (this.show_check) { 
           this.show = this.arcsiList.find(show => this.slugify(show.name) === this.slugify(this.show_title));  
           this.getLatestEpisodeFromArcsi()
-        }  
+        }
       }).catch((error) => {
         this.$sentry.captureException(new Error('Stream interrupted ', error))
         this.np_timeout = setTimeout(this.checkNowPlaying, 15000)

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -436,6 +436,8 @@ export default {
       this.$axios.get(this.nowPlayingUri).then((response) => {
         const npNew = response.data
         this.np = npNew
+        // Update show name in stream in store for other components
+        this.$store.commit('player/setStreamShowTitle', this.show_title())
         // Set a "default" current stream if none exists.
         if (this.current_stream.url === '' && npNew.station.listen_url !== '' && this.streams.length > 0) {
           let currentStream = null

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -127,8 +127,8 @@ import VueSlider from 'vue-slider-component/dist-css/vue-slider-component.umd.mi
 import 'vue-slider-component/dist-css/vue-slider-component.css'
 // import theme
 import 'vue-slider-component/theme/default.css'
-import { mapGetters } from 'vuex'
 import { arcsiBaseURL, config } from '~/constants'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -195,7 +195,7 @@ export default {
   },
   computed: {
     ...mapGetters({
-      todayShows: 'returnTodayShows'
+      getToday: 'returnTodayCET'
     }),
     streams () {
       const allStreams = []
@@ -217,8 +217,7 @@ export default {
       return [...this.$store.getters.returnArcsiShows]
     },
     currentShowArcsi () {
-      // This is a legacy duplication of the same data using via a computed function (currentShowArcsi) and data variable (this.show)
-      this.show = this.arcsiList.find(show => this.slugify(show.name) === this.show_title);  
+      // Legacy function used in building the page; this.show is computed elsewhere
       return this.show
     },
     time_percent () {
@@ -479,9 +478,9 @@ export default {
           })
           this.current_stream = currentStream
         }
-        // Optimisation: it should execute only once upon the first call
-        if (this.show == null) { // Also true if 'undefined'
-          this.show = this.arcsiList.find(show => this.slugify(show.name) === this.show_title);  
+        // Optimisation: it should execute only once upon the first call and only if it's a scheduled show going on
+        if (this.show == null && !this.show_check) { // Note: 'this.show == null' is also true if 'undefined'
+          this.show = this.arcsiList.find(show => this.slugify(show.name) === this.slugify(this.show_title));  
           this.getLatestEpisodeFromArcsi()
         }  
       }).catch((error) => {
@@ -527,17 +526,17 @@ export default {
         console.log(error)
         this.$nuxt.error({ statusCode: 404, message: 'Show archive not found' })
       })
-    }
-  },
-  // Helper method for getLatestEpisodeFromArcsi()
-  getLatestEpisode (episodes) {
-    const sortedItems = episodes
-    .filter(show => show.play_date < this.getToday)
-    .filter(show => show.archived === true)
-    .sort((a, b) => b.number - a.number)
-    .sort((a, b) => new Date(b.play_date) - new Date(a.play_date))
-    return sortedItems[0]
-  } 
+    },
+    // Helper method for getLatestEpisodeFromArcsi()
+    getLatestEpisode (episodes) {
+      const sortedItems = episodes
+      .filter(show => show.play_date < this.getTodayDateCET())
+      .filter(show => show.archived === true)
+      .sort((a, b) => b.number - a.number)
+      .sort((a, b) => new Date(b.play_date) - new Date(a.play_date))
+      return sortedItems[0]
+    } 
+  }
 }
 </script>
 

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -280,7 +280,7 @@ export default {
     },
     show_subtitle () {
       let title = ''
-      if (this.nowPlayingInfoAvailable) // Show metadata can be served from Azuracast nowplaing API response
+      if (this.nowPlayingInfoAvailable) // Show metadata can be served from Azuracast nowplaying API response
       {
         if (this.np.live.is_live) { 
           title = this.np.now_playing.song.title 
@@ -509,7 +509,7 @@ export default {
           })
           this.current_stream = currentStream
         }
-      // Compute show grouping from arcsi for schedule (Home) and player fallback (of nowplaying is not available)
+      // Compute show grouping from arcsi for schedule (Home) and player fallback (if nowplaying is not available)
       // Call for optimisation: don't call it unconditionally; note: now it's necessary for various reasons: 
       // 1. It needs to be computed for schedule at home -> computation cannot be bound to a state where nowplaying is not available
       // 2. We may need some recurring calculation logic if we want day changes not to need site reload
@@ -585,8 +585,8 @@ export default {
       })
     },
     // Helper method for getLatestEpisodeFromArcsi()
-    getLatestEpisode (episodes) {
-      const sortedItems = episodes.items
+    getLatestEpisode (currentShow) {
+      const sortedItems = currentShow.items
       // We need the unarchived items too (no audio uploaded yet) to cover relay streams too
       //.filter(show => show.archived === true) 
       .sort((a, b) => b.number - a.number)
@@ -594,7 +594,7 @@ export default {
       // Workaround: compute absoulate URL as current arcsi response doesn't have it
       let latestEp = sortedItems[0]
       const relativeURL = latestEp.image_url
-      latestEp.image_url = mediaServerURL +  episodes.archive_lahmastore_base_url + '/' + relativeURL  
+      latestEp.image_url = mediaServerURL +  currentShow.archive_lahmastore_base_url + '/' + relativeURL  
       return latestEp
     } 
   }

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -128,7 +128,6 @@ import 'vue-slider-component/dist-css/vue-slider-component.css'
 // import theme
 import 'vue-slider-component/theme/default.css'
 import { arcsiBaseURL, config } from '~/constants'
-import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -194,9 +193,9 @@ export default {
     }
   },
   computed: {
-    ...mapGetters({
-      getToday: 'returnTodayCET'
-    }),
+    getToday (){
+      return this.getTodayNumeric()
+    },
     streams () {
       const allStreams = []
       this.np.station.mounts.forEach(function (mount) {
@@ -479,7 +478,7 @@ export default {
           this.current_stream = currentStream
         }
         // Optimisation: it should execute only once upon the first call and only if it's a scheduled show going on
-        if (this.show == null && !this.show_check) { // Note: 'this.show == null' is also true if 'undefined'
+        if (this.show == null && this.show_check) { // Note: 'this.show == null' is also true if 'undefined'
           this.show = this.arcsiList.find(show => this.slugify(show.name) === this.slugify(this.show_title));  
           this.getLatestEpisodeFromArcsi()
         }  

--- a/app/components/schedule/Fullitem.vue
+++ b/app/components/schedule/Fullitem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="show && nowPlaying" class="dayblock" :class="showAirCheck(show.name) ? 'onair' : ''">
+  <div v-if="show" class="dayblock" :class="showAirCheck(show.name) ? 'onair' : ''">
     <div class="container mx-auto sm:flex show-basic-infos">
       <div class="mr-4 timing-infos">
         <div class="mb-2 time-block sm:mb-0">
@@ -75,10 +75,6 @@ export default {
     show: {
       type: Object,
       required: true
-    },
-    nowPlaying: {
-      type: Object,
-      required: true
     }
   },
   data () {
@@ -94,6 +90,11 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({   
+      streamShowTitle: 'player/getStreamShowTitle',
+      streamEpisodeTitle: 'player/getStreamEpisodeTitle',
+      onAirImage: 'player/getStreamEpisodeImageURL'
+    }),
     getToday () {
       const d = new Date()
       const year = d.getFullYear()
@@ -104,42 +105,7 @@ export default {
     isTouchEnabled () {
       return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)
     },
-    streamShowTitle () {
-      if (!this.nowPlaying.now_playing) {
-        return false
-      } else if (this.nowPlaying?.live?.is_live) {
-        return this.nowPlaying?.live?.streamer_name
-      } else {
-        return this.nowPlaying?.now_playing?.song.artist
-      }
-    },
-    streamEpisodeTitle () {
-      if (!this.nowPlaying.now_playing) {
-        return false
-      } else if (this.nowPlaying?.live?.is_live) {
-        return this.nowPlaying?.live?.song?.title || 'Live stream'
-      } else {
-        return this.nowPlaying?.now_playing?.song?.title
-      }
-    },
-    onAirImage () {
-      if (!this.nowPlaying.now_playing) {
-        return false
-      }
-      let streamImage
-      streamImage = this.nowPlaying.now_playing?.song?.art
-      if (this.nowPlaying.live.is_live) {
-        streamImage = this.show.cover_image_url
-      }
-      return this.showAirCheck(this.show.name) ? streamImage : this.show.cover_image_url
-    },
     onAirDescription () {
-      if (!this.nowPlaying.now_playing && this.latestEpisodeData) {
-        return false
-      }
-      if (this.nowPlaying?.live?.is_live) {
-        return this.show.description
-      }
       const descriptionFromArcsi = this.latestEpisodeData?.description
       return descriptionFromArcsi || this.show.description
     },

--- a/app/components/schedule/Fullitem.vue
+++ b/app/components/schedule/Fullitem.vue
@@ -96,13 +96,6 @@ export default {
       streamEpisodeTitle: 'player/getStreamEpisodeTitle',
       onAirImage: 'player/getStreamEpisodeImageURL'
     }),
-    getToday () {
-      const d = new Date()
-      const year = d.getFullYear()
-      const month = (d.getMonth() + 1).toLocaleString('en-US', { minimumIntegerDigits: 2 })
-      const day = d.getDate().toLocaleString('en-US', { minimumIntegerDigits: 2 })
-      return `${year}-${month}-${day}`
-    },
     isTouchEnabled () {
       return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)
     },
@@ -150,7 +143,7 @@ export default {
     },
     getLatestEpisode (episodes) {
       const sortedItems = episodes
-        .filter(show => show.play_date < this.getToday)
+        .filter(show => show.play_date < this.getTodayDateCET())
         .filter(show => show.archived === true)
         .sort((a, b) => b.number - a.number)
         .sort((a, b) => new Date(b.play_date) - new Date(a.play_date))

--- a/app/components/schedule/Fullitem.vue
+++ b/app/components/schedule/Fullitem.vue
@@ -110,12 +110,6 @@ export default {
       const descriptionFromArcsi = this.latestEpisodeData?.description
       return descriptionFromArcsi || this.show.description
     },
-    latestEpisodeImage () {
-      if (!this.latestEpisodeData) {
-        return false
-      }
-      return this.show.cover_image_url
-    },
     latestEpisodeTitle () {
       if (!this.latestEpisodeData) {
         return this.show.name

--- a/app/components/schedule/Fullitem.vue
+++ b/app/components/schedule/Fullitem.vue
@@ -119,6 +119,9 @@ export default {
       return episodeIdFromArcsi ? `/shows/${this.show.archive_lahmastore_base_url}/${episodeIdFromArcsi}` : baseLink
     }
   },
+  mounted () {
+    this.getShowInfos()
+  },
   methods: {
     showAirCheck (showname) {
       if (this.streamShowTitle && this.slugify(this.streamShowTitle) === this.slugify(showname)) {
@@ -132,7 +135,7 @@ export default {
       }
     },
     getShowInfos () {
-      this.$axios.get(arcsiBaseURL + '/show/' + this.show.archive_lahmastore_base_url + '/archive', config)
+      this.$axios.get(arcsiBaseURL + '/show/' + this.show.id, config)
         .then((res) => {
           this.latestEpisodeData = this.getLatestEpisode(res.data)
         })
@@ -142,9 +145,7 @@ export default {
         })
     },
     getLatestEpisode (episodes) {
-      const sortedItems = episodes
-        .filter(show => show.play_date < this.getTodayDateCET())
-        .filter(show => show.archived === true)
+      const sortedItems = episodes.items
         .sort((a, b) => b.number - a.number)
         .sort((a, b) => new Date(b.play_date) - new Date(a.play_date))
       return sortedItems[0]

--- a/app/components/schedule/Fullitem.vue
+++ b/app/components/schedule/Fullitem.vue
@@ -68,6 +68,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { arcsiBaseURL, config } from '~/constants'
 
 export default {

--- a/app/components/schedule/Home.vue
+++ b/app/components/schedule/Home.vue
@@ -78,9 +78,11 @@ export default {
     ...mapGetters({
       rareShows: 'returnRareShows',
       customSchedule: 'returnCustomSchedule',
-      streamShowTitle: 'player/getStreamShowTitle',
-      getToday: 'returnTodayCET'
+      streamShowTitle: 'player/getStreamShowTitle'
     }),
+    getToday (){
+      return this.getTodayNumeric()
+    },
     rareShowThursday () {
       if (!this.rareShows) {
         return false

--- a/app/components/schedule/Home.vue
+++ b/app/components/schedule/Home.vue
@@ -153,7 +153,7 @@ export default {
         })
       }
       this.showsByDate = [...list.slice(dayIndex), ...list.slice(0, dayIndex)]
-      this.$store.commit('returnTodayShows', showsByDate[0])
+      this.$store.commit('setTodayShows', this.showsByDate[0])
     }
   }
 

--- a/app/components/schedule/Home.vue
+++ b/app/components/schedule/Home.vue
@@ -78,7 +78,8 @@ export default {
   computed: {
     ...mapGetters({
       rareShows: 'returnRareShows',
-      customSchedule: 'returnCustomSchedule'
+      customSchedule: 'returnCustomSchedule',
+      streamShowTitle: 'player/getStreamShowTitle'
     }),
     rareShowThursday () {
       if (!this.rareShows) {
@@ -101,15 +102,6 @@ export default {
     },
     tommorrow () {
       return new Date(new Date())
-    },
-    streamShowTitle () {
-      if (!this.nowPlaying) {
-        return false
-      } else if (this.nowPlaying?.live?.is_live) {
-        return this.nowPlaying?.live?.streamer_name
-      } else {
-        return this.nowPlaying?.now_playing?.song.artist
-      }
     },
     todayName () {
       return this.dayNames[this.getToday - 1]

--- a/app/components/schedule/Home.vue
+++ b/app/components/schedule/Home.vue
@@ -67,7 +67,6 @@ export default {
       showsByDate: [],
       dayNames: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
       interval: null,
-      nowPlaying: {},
       latestRareThursday: null,
       latestRareFriday: null,
       customScheduleDay: null,
@@ -109,35 +108,12 @@ export default {
   },
   mounted () {
     this.groupShowsByDay(this.shows)
-    setTimeout(() => {
-      this.checkNowPlaying()
-    }, 1000)
-  },
-  beforeDestroy () {
-    // prevent memory leak
-    clearInterval(this.interval)
-  },
-  created () {
-    // update the time every minute
-    if (this.isClient) {
-      this.interval = setInterval(() => {
-        this.checkNowPlaying()
-      }, 60 * 1000)
-    }
   },
   methods: {
     showAirCheck (index, showname) {
       if (index === 0 && this.streamShowTitle && this.slugify(this.streamShowTitle) === this.slugify(showname)) {
         return true
       }
-    },
-    checkNowPlaying () {
-      this.$axios.get(this.streamServer).then((response) => {
-        this.nowPlaying = response.data
-      }).catch((error) => {
-        this.$sentry.captureException(new Error('Schedule not available ', error))
-        this.$nuxt.error({ statusCode: 404, message: 'Schedule not available' })
-      })
     },
     groupShowsByDay (shows) {
       if (!shows) { return false }

--- a/app/components/schedule/Home.vue
+++ b/app/components/schedule/Home.vue
@@ -64,36 +64,16 @@ export default {
       currentHost: typeof window !== 'undefined' ? window.location.origin : null,
       isClient: typeof window !== 'undefined' && window.document,
       streamServer,
-      showsByDate: [],
       dayNames: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
       interval: null,
-      latestRareThursday: null,
-      latestRareFriday: null,
-      customScheduleDay: null,
-      customScheduleEntries: null,
-      customPosition: null
     }
   },
   computed: {
     ...mapGetters({
-      rareShows: 'returnRareShows',
-      customSchedule: 'returnCustomSchedule',
       streamShowTitle: 'player/getStreamShowTitle'
     }),
     getToday (){
       return this.getTodayNumeric()
-    },
-    rareShowThursday () {
-      if (!this.rareShows) {
-        return false
-      }
-      return this.rareShows.rare_thursday.find(item => item.active === true)
-    },
-    rareShowFriday () {
-      if (!this.rareShows) {
-        return false
-      }
-      return this.rareShows.rare_friday.find(item => item.active === true)
     },
     todayDate () {
       return new Date()
@@ -103,59 +83,16 @@ export default {
     },
     todayName () {
       return this.dayNames[this.getToday - 1]
+    },
+    showsByDate () {
+      return this.$store.getters['player/getShowsByDate']
     }
-  },
-  mounted () {
-    this.groupShowsByDay(this.shows)
   },
   methods: {
     showAirCheck (index, showname) {
       if (index === 0 && this.streamShowTitle && this.slugify(this.streamShowTitle) === this.slugify(showname)) {
         return true
       }
-    },
-    groupShowsByDay (shows) {
-      if (!shows) { return false }
-      const list = []
-      const daybyMonday = this.getToday === 0 ? 7 : this.getToday
-      const dayIndex = daybyMonday - 1
-
-      this.latestRareThursday = shows
-        .filter(item => item?.playlist_name?.startsWith('Ritka csut'))
-        .filter(item => item?.archive_lahmastore_base_url !== this.rareShowThursday.archive_lahmastore_base_url)
-      this.latestRareFriday = shows
-        .filter(item => item?.playlist_name?.startsWith('Ritka pentek'))
-        .filter(item => item?.archive_lahmastore_base_url !== this.rareShowFriday.archive_lahmastore_base_url)
-
-      const filteredShows = shows
-        .filter(val => !this.latestRareThursday.includes(val))
-        .filter(val => !this.latestRareFriday.includes(val))
-
-      // custom Schedule Day
-      if (this.customSchedule?.is_active) {
-        this.customScheduleDay = parseInt(this.customSchedule.day_number, 10)
-        this.customScheduleEntries = this.customSchedule.schedule
-        // TODO fix the correct index
-        this.customPosition = this.customScheduleDay >= this.getToday ? this.customScheduleDay - this.getToday : (7 - this.getToday) + this.customScheduleDay
-      }
-
-      for (let i = 0; i < 7; i++) {
-        list.push([])
-        if (this.customScheduleDay - 1 === i) {
-          this.customScheduleEntries.forEach((entry) => {
-            list[i].push(entry)
-          })
-        }
-
-        filteredShows.forEach((show) => {
-          if (show.archive_lahmastore_base_url === 'off-air' || !show.active) { return false }
-          if (show.day - 1 === i && this.customScheduleDay - 1 !== i) {
-            list[i].push(show)
-          }
-        })
-      }
-      this.showsByDate = [...list.slice(dayIndex), ...list.slice(0, dayIndex)]
-      this.$store.commit('setTodayShows', this.showsByDate[0])
     }
   }
 

--- a/app/components/schedule/Home.vue
+++ b/app/components/schedule/Home.vue
@@ -104,6 +104,7 @@ export default {
     }
   },
   mounted () {
+    this.$store.commit('setTodayCET');
     this.groupShowsByDay(this.shows)
   },
   methods: {

--- a/app/components/schedule/Home.vue
+++ b/app/components/schedule/Home.vue
@@ -78,7 +78,8 @@ export default {
     ...mapGetters({
       rareShows: 'returnRareShows',
       customSchedule: 'returnCustomSchedule',
-      streamShowTitle: 'player/getStreamShowTitle'
+      streamShowTitle: 'player/getStreamShowTitle',
+      getToday: 'returnTodayCET'
     }),
     rareShowThursday () {
       if (!this.rareShows) {
@@ -91,10 +92,6 @@ export default {
         return false
       }
       return this.rareShows.rare_friday.find(item => item.active === true)
-    },
-    getToday () {
-      const d = new Date()
-      return d.getDay()
     },
     todayDate () {
       return new Date()
@@ -156,6 +153,7 @@ export default {
         })
       }
       this.showsByDate = [...list.slice(dayIndex), ...list.slice(0, dayIndex)]
+      this.$store.commit('returnTodayShows', showsByDate[0])
     }
   }
 

--- a/app/components/schedule/Home.vue
+++ b/app/components/schedule/Home.vue
@@ -106,7 +106,6 @@ export default {
     }
   },
   mounted () {
-    this.$store.commit('setTodayCET');
     this.groupShowsByDay(this.shows)
   },
   methods: {

--- a/app/components/schedule/LatestDay.vue
+++ b/app/components/schedule/LatestDay.vue
@@ -25,6 +25,8 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   props: {
     day: {
@@ -45,10 +47,9 @@ export default {
     }
   },
   computed: {
-    getToday () {
-      const d = new Date()
-      return d.getDay()
-    }
+        ...mapGetters({
+      getToday: 'returnTodayCET'
+    })
   },
   mounted () {
     if (this.index === this.getToday - 1) {

--- a/app/components/schedule/LatestDay.vue
+++ b/app/components/schedule/LatestDay.vue
@@ -25,7 +25,6 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
 
 export default {
   props: {
@@ -47,9 +46,9 @@ export default {
     }
   },
   computed: {
-        ...mapGetters({
-      getToday: 'returnTodayCET'
-    })
+    getToday (){
+      return this.getTodayNumeric()
+    }
   },
   mounted () {
     if (this.index === this.getToday - 1) {

--- a/app/pages/schedule.vue
+++ b/app/pages/schedule.vue
@@ -114,10 +114,10 @@ export default {
     }
   },
   mounted () {
-    this.groupShowsByDay(this.sortShowsForSchedule)
+    this.local_groupShowsByDay(this.sortShowsForSchedule)
   },
   methods: {
-    groupShowsByDay (shows) {
+    local_groupShowsByDay (shows) {
       if (!shows) { return false }
       const list = []
       const daybyMonday = this.getToday === 0 ? 7 : this.getToday

--- a/app/pages/schedule.vue
+++ b/app/pages/schedule.vue
@@ -75,9 +75,11 @@ export default {
     ...mapGetters({
       fullSchedule: 'returnArcsiShows',
       rareShows: 'returnRareShows',
-      customSchedule: 'returnCustomSchedule',
-      getToday: 'returnTodayCET'
+      customSchedule: 'returnCustomSchedule'
     }),
+    getToday (){
+      return this.getTodayNumeric()
+    },
     rareShowThursday () {
       if (!this.rareShows) {
         return false

--- a/app/pages/schedule.vue
+++ b/app/pages/schedule.vue
@@ -20,7 +20,7 @@
         <div v-for="(day, index) in dayNames" :key="index" :ref="index" class="dayschedule" :class="index === 0 ? 'block' : 'hidden'">
           <div v-for="(show, showindex) in showsByDate[index]" :key="index + showindex">
             <div v-if="customPosition === index">
-              <ScheduleCustom :show="show" :now-playing="nowPlaying" />
+              <ScheduleCustom :show="show" />
             </div>
             <div v-else>
               <ScheduleFullitem :show="show" :now-playing="nowPlaying" />

--- a/app/pages/schedule.vue
+++ b/app/pages/schedule.vue
@@ -23,7 +23,7 @@
               <ScheduleCustom :show="show" />
             </div>
             <div v-else>
-              <ScheduleFullitem :show="show" :now-playing="nowPlaying" />
+              <ScheduleFullitem :show="show" />
             </div>
           </div>
         </div>

--- a/app/pages/schedule.vue
+++ b/app/pages/schedule.vue
@@ -75,7 +75,8 @@ export default {
     ...mapGetters({
       fullSchedule: 'returnArcsiShows',
       rareShows: 'returnRareShows',
-      customSchedule: 'returnCustomSchedule'
+      customSchedule: 'returnCustomSchedule',
+      getToday: 'returnTodayCET'
     }),
     rareShowThursday () {
       if (!this.rareShows) {
@@ -99,10 +100,6 @@ export default {
         ))
         .sort((a, b) => a.day - b.day)
         .sort((a, b) => parseInt(a.start.replace(':', ''), 10) - parseInt(b.start.replace(':', ''), 10))
-    },
-    getToday () {
-      const d = new Date()
-      return d.getDay()
     },
     todayDate () {
       return new Date()

--- a/app/pages/schedule.vue
+++ b/app/pages/schedule.vue
@@ -122,6 +122,7 @@ export default {
       if (!shows) { return false }
       const list = []
       const daybyMonday = this.getToday === 0 ? 7 : this.getToday
+      //Current day's index
       const dayIndex = daybyMonday - 1
       this.latestRareThursday = shows
         .filter(item => item?.playlist_name?.startsWith('Ritka csut'))
@@ -153,6 +154,7 @@ export default {
           }
         })
       }
+      //2D array indexed by the week's days starting at current day; each array element is a 1D array listing the day's shows
       this.showsByDate = [...list.slice(dayIndex), ...list.slice(0, dayIndex)]
       this.dayNames = [...this.dayNames.slice(dayIndex), ...this.dayNames.slice(0, dayIndex)]
     },

--- a/app/pages/schedule.vue
+++ b/app/pages/schedule.vue
@@ -45,7 +45,6 @@ export default {
       selectedDay: 0,
       customPosition: null,
       interval: null,
-      nowPlaying: {},
       latestRareThursday: null,
       latestRareFriday: null
     }
@@ -117,21 +116,6 @@ export default {
   },
   mounted () {
     this.groupShowsByDay(this.sortShowsForSchedule)
-    setTimeout(() => {
-      this.checkNowPlaying()
-    }, 1000)
-  },
-  beforeDestroy () {
-    // prevent memory leak
-    clearInterval(this.interval)
-  },
-  created () {
-    // update the time every minute
-    if (this.isClient) {
-      this.interval = setInterval(() => {
-        this.checkNowPlaying()
-      }, 60 * 1000)
-    }
   },
   methods: {
     groupShowsByDay (shows) {
@@ -182,14 +166,6 @@ export default {
       this.$refs[dayindex][0].classList.remove('hidden')
       this.selectedDay = dayindex
     },
-    checkNowPlaying () {
-      this.$axios.get(this.streamServer).then((response) => {
-        this.nowPlaying = response.data
-      }).catch((error) => {
-        this.$sentry.captureException(new Error('Stream interrupted ', error))
-        this.interval = setTimeout(this.checkNowPlaying, 15000)
-      })
-    }
   }
 }
 </script>

--- a/app/plugins/mixinCommonMethods.js
+++ b/app/plugins/mixinCommonMethods.js
@@ -31,7 +31,7 @@ export function removeSeconds (time) {
 export function getCurrentTimeHourCET () {
   const d = new Date();
   //Return browser time's hour part in 24h style, e.g., 7 for 7am or 19 for 7pm, where time is CET
-  return d.toLocaleString("hu-HU", {timeZone: "Europe/Budapest", hour:"numeric"});
+  return d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", hour:"numeric"});
 }
 
 export function truncate (text, limit = 200) {

--- a/app/plugins/mixinCommonMethods.js
+++ b/app/plugins/mixinCommonMethods.js
@@ -28,6 +28,10 @@ export function removeSeconds (time) {
   return time.substring(0, time.length - 3)
 }
 
+export function removeMinutesAndSeconds (time) {
+  return time.substring(0, 1)
+}
+
 export function getCurrentTimeHourCET () {
   const d = new Date();
   //Return browser time's hour part in 24h style, e.g., 7 for 7am or 19 for 7pm, where time is CET

--- a/app/plugins/mixinCommonMethods.js
+++ b/app/plugins/mixinCommonMethods.js
@@ -28,6 +28,12 @@ export function removeSeconds (time) {
   return time.substring(0, time.length - 3)
 }
 
+export function getCurrentTimeHourCET () {
+  const d = new Date();
+  //Return browser time's hour part in 24h style, e.g., 7 for 7am or 19 for 7pm, where time is CET
+  return d.toLocaleString("hu-HU", {timeZone: "Europe/Budapest", hour:"numeric"});
+}
+
 export function truncate (text, limit = 200) {
   if (text.length <= limit) {
     return text

--- a/app/plugins/mixinCommonMethods.js
+++ b/app/plugins/mixinCommonMethods.js
@@ -38,6 +38,14 @@ export function getCurrentTimeHourCET () {
   return d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", hour:"numeric"});
 }
 
+export function getTodayDateCET () {
+  const d = new Date()
+  const year = d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", year: "numeric"}) 
+  const month = d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", month: "2-digit"}) 
+  const day = d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", day: "2-digit"})
+  return `${year}-${month}-${day}`    
+}
+
 export function truncate (text, limit = 200) {
   if (text.length <= limit) {
     return text
@@ -159,7 +167,9 @@ if (!Vue.__my_mixin__) {
       stripHTMLTags,
       getLanguageGraph,
       showFrequency,
-      getCorrectSlug
+      getCorrectSlug,
+      getCurrentTimeHourCET,
+      getTodayDateCET
     }
   })
 }

--- a/app/plugins/mixinCommonMethods.js
+++ b/app/plugins/mixinCommonMethods.js
@@ -38,6 +38,12 @@ export function getCurrentTimeHourCET () {
   return d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", hour:"numeric"});
 }
 
+export function getTodayNumeric () {
+  const d = new Date();
+  const CETdayString = d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", weekday:"long"});
+  return ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"].indexOf(CETdayString)  
+}
+
 export function getTodayDateCET () {
   const d = new Date()
   const year = d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", year: "numeric"}) 
@@ -169,7 +175,8 @@ if (!Vue.__my_mixin__) {
       showFrequency,
       getCorrectSlug,
       getCurrentTimeHourCET,
-      getTodayDateCET
+      getTodayDateCET,
+      getTodayNumeric
     }
   })
 }

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -5,8 +5,7 @@ export const state = () => ({
   allShowsList: {},
   rareShows: {},
   customSchedule: {},
-  todayShows: {},
-  todayCET: 0 //current weekday as numeric according to CET, Sunday is 0 etc.
+  todayShows: {}
 })
 
 export const actions = {
@@ -50,11 +49,6 @@ export const mutations = {
   },
   setTodayShows (state, tshows) {
     state.todayShows = tshows
-  },
-  setTodayCET (state) {
-    const d = new Date();
-    let CETdayString = d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", weekday:"long"});
-    state.todayCET = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"].indexOf(CETdayString)  
   }
 }
 
@@ -70,8 +64,5 @@ export const getters = {
   },
   returnTodayShows (state) {
     return state.todayShows
-  },
-  returnTodayCET (state) {
-    return state.todayCET
   }
 }

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -4,8 +4,7 @@ export const state = () => ({
   arcsiShows: {},
   allShowsList: {},
   rareShows: {},
-  customSchedule: {},
-  todayShows: {}
+  customSchedule: {}
 })
 
 export const actions = {
@@ -46,9 +45,6 @@ export const mutations = {
   },
   refreshCustomSchedule (state, payload) {
     state.customSchedule = payload
-  },
-  setTodayShows (state, tshows) {
-    state.todayShows = tshows
   }
 }
 
@@ -61,8 +57,5 @@ export const getters = {
   },
   returnCustomSchedule (state) {
     return state.customSchedule
-  },
-  returnTodayShows (state) {
-    return state.todayShows
   }
 }

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -11,16 +11,6 @@ export const state = () => ({
 
 export const actions = {
   async nuxtServerInit ({ state }, { $sentry, error }) {
-    /* Legacy api with all items
-    await this.$axios.get(arcsiServerURL)
-      .then((res) => {
-        state.arcsiShows = res.data
-      })
-      .catch((e) => {
-        $sentry.captureException(e)
-        error({ statusCode: 404, message: 'Arcsi Shows not found' })
-      })
-    */
     await this.$axios.get(arcsiShowsBaseURL + '/all_without_items', config)
       .then((res) => {
         state.allShowsList = res.data

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -1,10 +1,13 @@
+import { stat } from '@babel/core/lib/gensync-utils/fs'
 import { arcsiServerURL, arcsiShowsBaseURL, rareShowsURL, customScheduleURL, config } from '~/constants'
 
 export const state = () => ({
   arcsiShows: {},
   allShowsList: {},
   rareShows: {},
-  customSchedule: {}
+  customSchedule: {},
+  todayShows: {},
+  todayCET: 0 //current weekday as numeric according to CET, Sunday is 0 etc. 
 })
 
 export const actions = {
@@ -55,6 +58,14 @@ export const mutations = {
   },
   refreshCustomSchedule (state, payload) {
     state.customSchedule = payload
+  },
+  setTodayShows (state, tshows) {
+    state.todayShows = tshows
+  },
+  setTodayCET (state) {
+    const d = new Date();
+    let CETdayString = d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", weekday:"long"});
+    state.todayCET = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"].indexOf(day)(CETdayString)  
   }
 }
 
@@ -67,5 +78,11 @@ export const getters = {
   },
   returnCustomSchedule (state) {
     return state.customSchedule
+  },
+  returnTodayShows (state) {
+    return state.todayShows
+  },
+  returnTodayCET (state) {
+    return state.todayCET
   }
 }

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -6,7 +6,7 @@ export const state = () => ({
   rareShows: {},
   customSchedule: {},
   todayShows: {},
-  todayCET: 0 //current weekday as numeric according to CET, Sunday is 0 etc. 
+  todayCET: 0 //current weekday as numeric according to CET, Sunday is 0 etc.
 })
 
 export const actions = {

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -1,4 +1,3 @@
-import { stat } from '@babel/core/lib/gensync-utils/fs'
 import { arcsiServerURL, arcsiShowsBaseURL, rareShowsURL, customScheduleURL, config } from '~/constants'
 
 export const state = () => ({
@@ -65,7 +64,7 @@ export const mutations = {
   setTodayCET (state) {
     const d = new Date();
     let CETdayString = d.toLocaleString("en-EN", {timeZone: "Europe/Budapest", weekday:"long"});
-    state.todayCET = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"].indexOf(day)(CETdayString)  
+    state.todayCET = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"].indexOf(CETdayString)  
   }
 }
 

--- a/app/store/player.js
+++ b/app/store/player.js
@@ -1,6 +1,8 @@
 export const state = () => ({
   isStreamPlaying: false,
   streamShowTitle: "",
+  streamEpisodeTitle: "",
+  streamEpisodeImageURL: "",
   streamVolume: 55,
   arcsiEpisode: {},
   arcsiPlayHistory: {},
@@ -15,6 +17,12 @@ export const mutations = {
   },
   setStreamShowTitle (state, title) {
     state.streamShowTitle = title
+  },
+  setStreamEpisodeTitle (state, title) {
+    state.streamEpisodeTitle = title
+  },
+  setStreamEpisodeImageURL (state, url) {
+    state.streamEpisodeImageURL = url
   },
   currentlyPlayingArcsi (state, episode) {
     state.arcsiEpisode = episode
@@ -67,5 +75,11 @@ export const getters = {
   },
   getStreamShowTitle (state) {
     return state.streamShowTitle
-  }
+  },
+  getStreamEpisodeTitle (state) {
+    return state.streamShowEpisode
+  },
+  getStreamEpisodeImageURL (state) {
+    return state.streamEpisodeImageURL
+  }  
 }

--- a/app/store/player.js
+++ b/app/store/player.js
@@ -8,7 +8,8 @@ export const state = () => ({
   arcsiPlayHistory: {},
   arcsiVolume: 1,
   isArcsiPlaying: false,
-  isArcsiVisible: false
+  isArcsiVisible: false,
+  showsByDate: []
 })
 
 export const mutations = {
@@ -47,6 +48,9 @@ export const mutations = {
   },
   isArcsiVisible (state, showState) {
     state.isArcsiVisible = showState
+  },
+  setShowsByDate (state, shows) {
+    state.showsByDate = shows
   }
 
 }
@@ -76,10 +80,13 @@ export const getters = {
   getStreamShowTitle (state) {
     return state.streamShowTitle
   },
-  getStreamEpisodeTitle (state) {
-    return state.streamShowEpisode
+  getStreamEpisodeTitle (state) {  
+    return state.streamEpisodeTitle
   },
   getStreamEpisodeImageURL (state) {
     return state.streamEpisodeImageURL
-  }  
+  },
+  getShowsByDate (state) {
+    return state.showsByDate
+  }
 }

--- a/app/store/player.js
+++ b/app/store/player.js
@@ -1,5 +1,6 @@
 export const state = () => ({
   isStreamPlaying: false,
+  streamShowTitle: "",
   streamVolume: 55,
   arcsiEpisode: {},
   arcsiPlayHistory: {},
@@ -11,6 +12,9 @@ export const state = () => ({
 export const mutations = {
   isStreamPlaying (state, trigger) {
     state.isStreamPlaying = trigger
+  },
+  setStreamShowTitle (state, title) {
+    state.streamShowTitle = title
   },
   currentlyPlayingArcsi (state, episode) {
     state.arcsiEpisode = episode

--- a/app/store/player.js
+++ b/app/store/player.js
@@ -64,5 +64,8 @@ export const getters = {
   },
   getStreamPlayState (state) {
     return state.isStreamPlaying
+  },
+  getStreamShowTitle (state) {
+    return state.streamShowTitle
   }
 }


### PR DESCRIPTION
Main changes: 

- Add displaying relayed streams feauture (see Wiki for usage: https://github.com/lahmacunradio/frontend/wiki/How-to-handle-relayed-streams-as-shows); 
   - Main logic: so far the player info (title, subtitle, image link) was solely filled based on the `nowplaying` API answer from the streaming server (Azuracast); this new feature introduces a fallback mechanism if such info is not available. Specifically, in case of stream relays there is no image link and the title and subtitle fields depend on the streamer. We use the combination of the `playlist` (empty) and `is_live` (false) fields to detect such a case and we fallback to compute the show based on the current CET time and arcsi. 
- Fix some CET issues (CET display and calculating CET times to be in sunch with arcsi schedules);
- Start using store (Vue's "global variable" concept) for sharing/reusing data across components (most notably in this PR: radio player component computes show info such as title, subtitle which is reused by, e.g., schedule on home page). 

Fixed issues:

- https://github.com/lahmacunradio/frontend/issues/278
- https://github.com/lahmacunradio/frontend/issues/280

Validation: 

- Tested locally with relay streams and for regression (live, scheduled shows etc.), 
- Deployed on dev server. 

Known issues (to be done later) and disclaimer: 

- https://github.com/lahmacunradio/frontend/issues/279
- Commits are sometimes chaotic, I needed to backtrack here and there. 
- Internal arcsi API (meant for arcsi UI) used to request unarchived show items too (see in usage doc above). 

**Please review until Monday if you can and sorry for the very short notice! It got to be a more complicated feature than I expected.** 