### PR TITLE
Dev/#289 don't list future eps

### DIFF
--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -566,31 +566,15 @@ export default {
       this.streamModal = false
     },
     getLatestEpisodeFromArcsi() {
-    // TODO: use dedicated frontend API instead of one meant for arcsi UI (rationale: we need the unarchived episodes too for relay logic and there was no such frontend arcsi API available)  
-    // TODO: see also related workaround in getLatestEpisode ()
-    this.$axios.get(arcsiBaseURL + '/show/' + this.show.id, config)
+    this.$axios.get(arcsiBaseURL + '/show/' + this.slugify(this.show.name) + '/page?filter=latest', config)
       .then((res) => {
-        this.latestEpisodeData = this.getLatestEpisode(res.data)
+        this.latestEpisodeData = res.data.items //note that it's a sinlge item with filter latest, plural in var name is misleading
       })
       .catch((error) => {
         console.log(error)
         this.$nuxt.error({ statusCode: 404, message: 'Show archive not found' })
       })
     },
-    // Helper method for getLatestEpisodeFromArcsi()
-    getLatestEpisode (currentShow) {
-      if (currentShow.items.length != 0){
-      const sortedItems = currentShow.items
-      // We need the unarchived items too (no audio uploaded yet) to cover relay streams too
-      //.filter(show => show.archived === true) 
-      .sort((a, b) => b.id - a.id)
-      // Workaround: compute absoulate URL as current arcsi response doesn't have it
-      let latestEp = sortedItems[0]
-      const relativeURL = latestEp.image_url
-      latestEp.image_url = mediaServerURL +  currentShow.archive_lahmastore_base_url + '/' + relativeURL  
-      return latestEp
-      }
-    } 
   }
 }
 </script>

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -566,15 +566,31 @@ export default {
       this.streamModal = false
     },
     getLatestEpisodeFromArcsi() {
-    this.$axios.get(arcsiBaseURL + '/show/' + this.slugify(this.show.name) + '/page?filter=latest', config)
+    // TODO: use dedicated frontend API instead of one meant for arcsi UI (rationale: we need the unarchived episodes too for relay logic and there was no such frontend arcsi API available)  
+    // TODO: see also related workaround in getLatestEpisode ()
+    this.$axios.get(arcsiBaseURL + '/show/' + this.show.id, config)
       .then((res) => {
-        this.latestEpisodeData = res.data.items //note that it's a sinlge item with filter latest, plural in var name is misleading
+        this.latestEpisodeData = this.getLatestEpisode(res.data)
       })
       .catch((error) => {
         console.log(error)
         this.$nuxt.error({ statusCode: 404, message: 'Show archive not found' })
       })
     },
+    // Helper method for getLatestEpisodeFromArcsi()
+    getLatestEpisode (currentShow) {
+      if (currentShow.items.length != 0){
+      const sortedItems = currentShow.items
+      // We need the unarchived items too (no audio uploaded yet) to cover relay streams too
+      //.filter(show => show.archived === true) 
+      .sort((a, b) => b.id - a.id)
+      // Workaround: compute absoulate URL as current arcsi response doesn't have it
+      let latestEp = sortedItems[0]
+      const relativeURL = latestEp.image_url
+      latestEp.image_url = mediaServerURL +  currentShow.archive_lahmastore_base_url + '/' + relativeURL  
+      return latestEp
+      }
+    } 
   }
 }
 </script>

--- a/app/components/schedule/Custom.vue
+++ b/app/components/schedule/Custom.vue
@@ -26,7 +26,7 @@
             </a>
           </div>
           <div v-else-if="show.archive_lahmastore_base_url">
-            <NuxtLink :to="'shows/' + show.archive_lahmastore_base_url.replace(currentHost, '')">
+            <NuxtLink :to="'/shows/' + show.archive_lahmastore_base_url.replace(currentHost, '')">
               <b>{{ show.name }}</b>
             </NuxtLink>
           </div>

--- a/app/components/schedule/Fullitem.vue
+++ b/app/components/schedule/Fullitem.vue
@@ -43,7 +43,7 @@
             <div class="text-sm description">
               <div v-sanitize="[ sanitizeOptions, show.description ]" class="description-text" />
               <p v-if="latestEpisodeData" class="mt-2">
-                Episode highlight:
+                Last in archive:
                 <NuxtLink :to="latestEpisodeLink">
                   <b>{{ latestEpisodeTitle }}</b>
                 </NuxtLink>
@@ -135,21 +135,15 @@ export default {
       }
     },
     getShowInfos () {
-      this.$axios.get(arcsiBaseURL + '/show/' + this.show.id, config)
+      this.$axios.get(arcsiBaseURL + '/show/' + this.slugify(this.show.name) + '/page?filter=archived,latest', config)
         .then((res) => {
-          this.latestEpisodeData = this.getLatestEpisode(res.data)
+          this.latestEpisodeData = res.data.items //note that it's a sinlge item with filter latest, plural in var name is misleading
         })
         .catch((error) => {
           console.log(error)
           this.$nuxt.error({ statusCode: 404, message: 'Show archive not found' })
         })
     },
-    // Note: we currently show future and unarchived episodes too (see "Episode highlight" wording in HTML render part above)
-    getLatestEpisode (currentShow) {
-      const sortedItems = currentShow.items
-        .sort((a, b) => b.id - a.id)
-      return sortedItems[0]
-    }
   }
 }
 </script>

--- a/app/pages/shows/_slug/_id.vue
+++ b/app/pages/shows/_slug/_id.vue
@@ -149,7 +149,7 @@ export default {
           }
         })
       //Fetch show data
-      await this.$axios.get(arcsiBaseURL + '/show/' + this.slug + '/page', config)
+      await this.$axios.get(arcsiBaseURL + '/show/' + this.slug + '/page?filter=archived', config)
         .then((res) => {
             this.arcsiShow = res.data
         })
@@ -226,8 +226,6 @@ export default {
       if (this.arcsiShow && this.arcsiShow.items?.length) {
         const itemsSorted = this.arcsiShow?.items
           .filter(item => item.id !== this.arcsiEpisode.id)
-          .filter(show => show.play_date < this.getToday)
-          .filter(show => show.archived === true)
           .sort((a, b) => b.number - a.number)
           .sort((a, b) => new Date(b.play_date) - new Date(a.play_date))
         if (this.airtimeAsc && this.sortingType === 'air') {

--- a/app/pages/shows/_slug/index.vue
+++ b/app/pages/shows/_slug/index.vue
@@ -131,7 +131,7 @@ export default {
     }
   },
   async fetch () {
-    this.showObject = await this.$axios.get(arcsiBaseURL + '/show/' + this.slug + '/page', config)
+    this.showObject = await this.$axios.get(arcsiBaseURL + '/show/' + this.slug + '/page?filter=archived', config)
       .then(res => res.data)
       .catch((error) => {
         this.$nuxt.error({ statusCode: 404, message: 'Show page not found' + error })
@@ -176,8 +176,6 @@ export default {
     arcsiEpisodesList () {
       if (this.showObject?.items) {
         const itemsSorted = this.showObject.items
-          .filter(show => show.play_date < this.getToday)
-          .filter(show => show.archived === true)
           .sort((a, b) => b.number - a.number)
           .sort((a, b) => new Date(b.play_date) - new Date(a.play_date))
         if (this.airtimeAsc && this.sortingType === 'air') {

--- a/app/plugins/mixinCommonMethods.js
+++ b/app/plugins/mixinCommonMethods.js
@@ -73,8 +73,8 @@ export function slugify (str) {
   str = str.toLowerCase()
 
   // remove accents, swap ñ for n, etc
-  const from = 'àáäâèéëêìíïîòóöôùúüûñç·/_,:;'
-  const to = 'aaaaeeeeiiiioooouuuunc------'
+  const from = 'àáäâèéëêìíïîòóöôőùúüûűñç·/_,:;'
+  const to = 'aaaaeeeeiiiiooooouuuuunc------'
   for (let i = 0, l = from.length; i < l; i++) {
     str = str.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i))
   }


### PR DESCRIPTION
This is primarily a bug fix change and also an arcsi API usage consolidation one (thanks @tuz666 & @pvj for the great work on the new arcsi API version!). As it's bug fix, please review asap. 

Related issues:
- #288 
- #289 

Tests/validation done: 
- Deployed locally; 
- Local regression tests (quick & best effort): custom schedule, live show, relayed show, regular schedule; 
- Deployed on dev (for your quick validation); 