### PR TITLE
Dev/#292 migrate from ua to ga4

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -3,7 +3,7 @@
   <head {{ HEAD_ATTRS }}>
     {{ HEAD }}
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-149605744-1"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-333552546"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}

--- a/app/app.html
+++ b/app/app.html
@@ -9,7 +9,7 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'UA-149605744-1');
+      gtag('config', 'G-333552546');
     </script>
   </head>
   <body {{ BODY_ATTRS }}>

--- a/app/app.html
+++ b/app/app.html
@@ -3,13 +3,13 @@
   <head {{ HEAD_ATTRS }}>
     {{ HEAD }}
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-333552546"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-QRXH6NC29Q"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-333552546');
+      gtag('config', 'G-QRXH6NC29Q');
     </script>
   </head>
   <body {{ BODY_ATTRS }}>

--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -434,9 +434,8 @@ export default {
       if (this.show_check) {
         // eslint-disable-next-line no-undef
         gtag('event', 'Radio play', {
-          event_category: this.show_title,
-          event_label: this.show_subtitle,
-          value: 1
+          show_title: this.show_title,
+          episode_title: this.show_subtitle
         })
       }
 

--- a/app/components/arcsi/Player.vue
+++ b/app/components/arcsi/Player.vue
@@ -259,8 +259,8 @@ export default {
       // Google Analytics 3 play event
       // eslint-disable-next-line no-undef
       gtag('event', 'Arcsi play', {
-        event_category: this.episode.shows[0].name,
-        event_label: this.episode.name,
+        show_title: this.episode.shows[0].name,
+        episode_title: this.episode.name,
         value: 1
       })
     },


### PR DESCRIPTION
**Rationale**: in 4 days, Universal Analytics (UA) will stop to deliver data. Our show and episode titles are currently sent via UA custom events. As a result, starting in 4 days, we won't have this information. 

**This PR**: changes the measurement ID from UA to GA4 (as configured in the Google Analytics admin page) and sends GA4-compatible custom events. These custom events are different from our prev. UA ones: 
- Instead of using the built-in `event category` and `event action` parameters, we now introduced custom `show_title` and `episode_title` parameters (note that we don't use Google Tag Manager).  
- These new parameters are handled (in suitable queries, specifically, "explorations" and "custom dimensions") in the Google Analytics admin. 

**Disclaimer and tests**:
-  Measurement ID could be taken from local file but as it needs to be in the page's code (as a parameter to the Google JS file), it's not a secret, and this is how we did it so far too. 
- Custom events have been tested on dev, and we can reproduce all stats that we've had so far. 

**Related issues**:
- https://github.com/lahmacunradio/frontend/issues/292

Please review asap (see above timeline). 