### PR TITLE
Bug fix: quick frontend side fix for schedule corner case w/ no episode

### DIFF
--- a/app/components/schedule/Fullitem.vue
+++ b/app/components/schedule/Fullitem.vue
@@ -141,7 +141,7 @@ export default {
         })
         .catch((error) => {
           console.log(error)
-          this.$nuxt.error({ statusCode: 404, message: 'Show archive not found' })
+          //this.$nuxt.error({ statusCode: error.response.status, message: "Show's latest episode could not be fetched: " + error.message })
         })
     },
   }


### PR DESCRIPTION
This is a frontend side quick fix so that error is not generated when the API calls fails. Note that the render is OK (robust) as the episode data is simply not shown.  #296