### PR TITLE
Quick fix for donate and membership parameters

### DIFF
--- a/app/pages/donate.vue
+++ b/app/pages/donate.vue
@@ -26,16 +26,15 @@
 
                 <div class="flex flex-col gap-2 my-4 radios">
                   <div class="flex items-center gap-2">
-                    <RadioButton id="one-time" inputId="one-time" name="donate" value="no" v-model="is_recurring" />
+                    <RadioButton id="one-time" inputId="one-time" name="is_recurring" value="no" v-model="is_recurring" />
                     <label for="one-time">{{ donateContent?.acf?.one_time }}</label>
                   </div>
                   <div class="flex items-center gap-2">
-                    <RadioButton id="recurring" inputId="recurring" name="donate" value="yes" v-model="is_recurring" />
+                    <RadioButton id="recurring" inputId="recurring" name="is_recurring" value="yes" v-model="is_recurring" />
                     <label for="recurring">{{ donateContent?.acf?.recurring }}</label>
                   </div>
 
                 </div>
-                <input type="hidden" name="is_recurring" :value="is_recurring">
 
               </div>
 

--- a/app/pages/membership.vue
+++ b/app/pages/membership.vue
@@ -21,6 +21,7 @@
                 <label class="text-sm mb-1">Select your show</label>
                 <Dropdown v-model="show_name" :options="arcsiShowsList" placeholder="Choose from list" scrollHeight="300px" />
               </div>
+              <input type="hidden" name="show_name" :value="show_name">
               <button type="submit" id="checkout-button" :disabled="show_name.length === 0">Continue for payment</button>
             </form>
             <p>Cancel your subscription


### PR DESCRIPTION
- Remove additional `donate` param from Donate page's Stripe params
- Add hidden `show_name` param for Membership page's Stripe param